### PR TITLE
Check for url before url.match

### DIFF
--- a/Source/History.js
+++ b/Source/History.js
@@ -21,7 +21,7 @@ provides: History
 var events = Element.NativeEvents,
 	location = window.location,
 	cleanURL = function(url){
-		if (url.match(/^https?:\/\//)) url = '/' + url.split('/').slice(3).join('/');
+		if (url && url.match(/^https?:\/\//)) url = '/' + url.split('/').slice(3).join('/');
 		return url;
 	},
 	base = cleanURL(location.href),


### PR DESCRIPTION
If we do not check if url is set, we may get an "Uncaught TypeError: Cannot call method 'match' of undefined". I see that error (exactly at the `url.catch` line) in my remote error logging statistics about 5-10 times a day.

Maybe location.href (which is used in the History plugin) is blocked by some agressive Browser plugin or my implementation is wrong. But I don't think I made something wrong, because the only way I use the History plugin is `History.push('#overlay');` and `History.back();`.
